### PR TITLE
#160949299 Increase timeout between proxy connection

### DIFF
--- a/deploy/travela-backend.config.tpl
+++ b/deploy/travela-backend.config.tpl
@@ -24,7 +24,7 @@ SERVICE_ACCOUNTS=()
 SECRETS=('travela-backend' 'travela-tls')
 
 # List of files ending in '.service.yml' in the kube directory
-SERVICES=('travela-backend' 'nginx')
+SERVICES=('travela-backend')
 
 # List of ingress resource files ending in '.ingress.yml' in the kube directory
 INGRESSES=("travela-{{ NAMESPACE }}")

--- a/deploy/travela-frontend.config.tpl
+++ b/deploy/travela-frontend.config.tpl
@@ -24,7 +24,7 @@ SERVICE_ACCOUNTS=()
 SECRETS=('travela-tls')
 
 # List of files ending in '.service.yml' in the kube directory
-SERVICES=('travela-frontend' 'nginx')
+SERVICES=('travela-frontend')
 
 # List of ingress resource files ending in '.ingress.yml' in the kube directory
 INGRESSES=("travela-{{ NAMESPACE }}")

--- a/deploy/travela-staging.ingress.yml.tpl
+++ b/deploy/travela-staging.ingress.yml.tpl
@@ -10,8 +10,8 @@ metadata:
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: 3600
-    nginx.ingress.kubernetes.io/proxy-send-timeout: 3600
+    nginx.ingress.kubernetes.io/proxy-read-timeout: 86400
+    nginx.ingress.kubernetes.io/proxy-send-timeout: 86400
 spec:
   tls:
     - secretName: travela-tls-secrets

--- a/deploy/travela-staging.ingress.yml.tpl
+++ b/deploy/travela-staging.ingress.yml.tpl
@@ -10,6 +10,8 @@ metadata:
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: 3600
+    nginx.ingress.kubernetes.io/proxy-send-timeout: 3600
 spec:
   tls:
     - secretName: travela-tls-secrets


### PR DESCRIPTION
#### What does this PR do?
- Increases time between two successive read and send proxy operations
- It stops nginx.service.yml deployment from happening via circleci

#### Description of Task to be completed?
Currently, the timeout between consecutive proxy send and read is 60 seconds, if there is no communication between the client and the server within 60 seconds, the connection gets closed, thus leading to an error code of 400 by the web socket.

Increase the timeout to be 3600 seconds (1 hour) before the connection gets closed.

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
I stopped the nginx.service.yml file deployment from happening via circleci because this service is in another namespace than where the rok8s-scripts are deploying to, and thus an error was being thrown.

#### What are the relevant pivotal tracker stories?
#160949299

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A