### PR TITLE
#161449761 Have TLS termination for production

### DIFF
--- a/deploy/travela-production.ingress.yml.tpl
+++ b/deploy/travela-production.ingress.yml.tpl
@@ -10,9 +10,11 @@ metadata:
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: 86400
+    nginx.ingress.kubernetes.io/proxy-send-timeout: 86400
 spec:
   tls:
-    - secretName: {{ PROJECT_NAME }}-tls-secrets
+    - secretName: travela-tls-secrets
   rules:
   - host: travela.andela.com
     http:


### PR DESCRIPTION
#### What does this PR do?
- corrects the name of the TLS secret in the ingress file

#### Description of Task to be completed?
Currently, the ingress for the production points to the wrong secret object for TLS, which does not even exists. Correct the ingress to use the correct TLS secret.

#### How should this be manually tested?
After this PR has been merged, try visiting https://travela.andela.com

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/161449764
https://www.pivotaltracker.com/story/show/161449761

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A