### PR TITLE
#161472146 Enforce kubelet to always pull image

### DIFF
--- a/deploy/travela-backend.deployment.yml.tpl
+++ b/deploy/travela-backend.deployment.yml.tpl
@@ -14,6 +14,7 @@ spec:
       containers:
         - name: {{ PROJECT_NAME }}
           image: {{ DOCKER_REGISTRY }}/{{ PROJECT_ID }}/{{ PROJECT_NAME }}:{{ IMAGE_TAG }}
+          imagePullPolicy: Always
           command:
             - node
             - index.js

--- a/deploy/travela-frontend.deployment.yml.tpl
+++ b/deploy/travela-frontend.deployment.yml.tpl
@@ -14,6 +14,7 @@ spec:
       containers:
         - name: {{ PROJECT_NAME }}
           image: {{ DOCKER_REGISTRY }}/{{ PROJECT_ID }}/{{ PROJECT_NAME }}:{{ IMAGE_TAG }}
+          imagePullPolicy: Always
           command:
             - serve
             - -s


### PR DESCRIPTION
#### What does this PR do?
- Enforces kubelet to always pull an image.

#### Description of Task to be completed?
Currently, when we re-deploy to kubernetes, the kubelet does not pull an image, and thus, if there are any changes to the environment variables, they would not be picked.

Change the configurations in the deployment such that kubelet always pulls an image regardless of whether the image exists or not.

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/161472144
https://www.pivotaltracker.com/story/show/161472146

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
