### PR TITLE
chore(labelling): label gcp resources being used by travela

### DIFF
--- a/terraform/gke/cluster.tf
+++ b/terraform/gke/cluster.tf
@@ -3,6 +3,14 @@ resource "google_container_cluster" "travela-cluster" {
   zone               = "${var.zone}"
   network = "${google_compute_network.travela-network.self_link}"
   subnetwork = "${google_compute_subnetwork.travela-subnet.self_link}"
+  resource_labels = {
+    product = "${var.product}"
+    component = "frontend_backend"
+    env = "${var.environment}"
+    owner = "${var.owner}"
+    maintainer = "${var.maintainer}"
+    state = "in_use"
+  }
   node_pool = [{
     name = "default-pool"
     node_count = 2

--- a/terraform/gke/variables.tf
+++ b/terraform/gke/variables.tf
@@ -2,3 +2,6 @@ variable "project" {}
 variable "region" {}
 variable "zone" {}
 variable "environment" {}
+variable "product" {}
+variable "owner" {}
+variable "maintainer" {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,6 @@
 variable "project" {}
+variable "owner" {}
+variable "maintainer" {}
 
 locals {
   region = "${terraform.workspace == "staging" ? "us-central1" : "europe-west1"}"
@@ -18,4 +20,7 @@ module "gke" {
   environment = "${terraform.workspace}"
   region = "${local.region}"
   zone = "${local.zone}"
+  product = "travela"
+  owner = "${var.owner}"
+  maintainer = "${var.maintainer}"
 }


### PR DESCRIPTION
#### What does this PR do?
- It labels the cluster being used by travela

#### Description of Task to be completed?
### Why


**As Laolu**
**I want to be able to break down costs accrued on GCP because of the resources used by Travela**
**So that Laolu can effectively manage costs accrued on GCP**

### Acceptance Criteria

```
Scenario: 
Given project admin on GCP wants to know how much costs have accrued due to Travela
When the project admin on GCP exports billing data, s/he can filter out costs accrued because of Travela using labels attached to resources used by Travela
Then the project admin on GCP can take appropriate decisions for Travela keeping the charges Travela accrues
```

**Notes:**
Use the *DevOps Apprenticeship Practice Guide* to label the resources.
Resources that are created by Terraform, use Terraform to label them.

#### How should this be manually tested?
By following this: https://cloud.google.com/blog/products/gcp/use-labels-to-gain-visibility-into-gcp-resource-usage-and-spending?hl=nl
and filtering out the resources according to Travela product.

#### Any background context you want to provide?
I have hardcoded some values for some labels as opposed to making them variables because they are specific to that particular resource.

#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/164044044
https://www.pivotaltracker.com/story/show/164070466

#### Screenshots (if appropriate)
<img width="1230" alt="screen shot 2019-02-19 at 11 40 09" src="https://user-images.githubusercontent.com/18000724/53001825-9987b280-343c-11e9-865f-23027b02675c.png">

#### Questions:
