### PR TITLE
DA-107 Refine terraform scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bin/*.envs
 .DS_Store
 bucketPolicy/.env
 bucketPolicy/creds/serviceAccount.json
+*.tfvars
+terraformV2/gke/creds/serviceAccount.json

--- a/terraformV2/gke/cluster.tf
+++ b/terraformV2/gke/cluster.tf
@@ -1,0 +1,21 @@
+resource "google_container_cluster" "travela-cluster" {
+  name       = "travela-tf-${var.environment}"
+  location   = "${var.location}"
+  network    = "${google_compute_network.travela-network.self_link}"
+  subnetwork = "${google_compute_subnetwork.travela-subnet.self_link}"
+
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  resource_labels = {
+    product    = "${var.product}"
+    component  = "frontend_backend"
+    env        = "${var.environment}"
+    owner      = "${var.owner}"
+    maintainer = "${var.maintainer}"
+    state      = "in_use"
+  }
+}

--- a/terraformV2/gke/db.tf
+++ b/terraformV2/gke/db.tf
@@ -1,0 +1,42 @@
+provider "random" {
+  version = "~> 2.1"
+}
+
+resource "random_id" "travela-db-user-password" {
+  byte_length = 16
+}
+
+resource "google_sql_database_instance" "travela-db-instance" {
+  region           = "${var.region}"
+  database_version = "POSTGRES_9_6"
+  name             = "${var.environment}-travela-db-instance"
+
+  settings {
+    tier              = "${var.db_instance_tier}"
+    availability_type = "REGIONAL"
+    disk_autoresize   = true
+
+    ip_configuration {
+      ipv4_enabled = true
+    }
+
+    backup_configuration {
+      enabled    = true
+      start_time = "${var.db_backup_start_time}"
+    }
+  }
+}
+
+resource "google_sql_database" "travela-database" {
+  name      = "${var.environment}-travela-database"
+  instance  = "${google_sql_database_instance.travela-db-instance.name}"
+  charset   = "UTF8"
+  collation = "en_US.UTF8"
+}
+
+resource "google_sql_user" "travela-database-user" {
+  name     = "${var.db_user}"
+  password = "${random_id.travela-db-user-password.b64}"
+  instance = "${google_sql_database_instance.travela-db-instance.name}"
+  host     = ""
+}

--- a/terraformV2/gke/gcp.tf
+++ b/terraformV2/gke/gcp.tf
@@ -1,0 +1,6 @@
+provider "google" {
+  version     = "~> 2.8.0"
+  project     = "${var.project}"
+  region      = "${var.region}"
+  credentials = "${var.credentials}"
+}

--- a/terraformV2/gke/network.tf
+++ b/terraformV2/gke/network.tf
@@ -1,0 +1,16 @@
+resource "google_compute_network" "travela-network" {
+  name                    = "travela-tf-${var.environment}-vpc"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_subnetwork" "travela-subnet" {
+  name                     = "travela-tf-${var.environment}-subnet"
+  ip_cidr_range            = "10.0.0.0/18"
+  network                  = "${google_compute_network.travela-network.self_link}"
+  private_ip_google_access = "true"
+}
+
+resource "google_compute_address" "travela-static-address" {
+  name         = "travela-tf-${var.environment}-static-address"
+  address_type = "EXTERNAL"
+}

--- a/terraformV2/gke/node.tf
+++ b/terraformV2/gke/node.tf
@@ -1,0 +1,36 @@
+resource "google_container_node_pool" "travela-node-pool" {
+  name       = "travela-tf-${var.environment}-node-pool"
+  location   = "${var.location}"
+  cluster    = "${google_container_cluster.travela-cluster.name}"
+  node_count = 3
+
+  // Configuration for each node to be created
+  node_config {
+    preemptible  = true
+    machine_type = "${var.machine_type}"
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+
+    // set of google API's made available on all of the nodes
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring.write",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ]
+  }
+
+  autoscaling {
+    min_node_count = 3
+    max_node_count = 6
+  }
+
+  management {
+    auto_upgrade = true
+    auto_repair  = true
+  }
+}

--- a/terraformV2/gke/variables.tf
+++ b/terraformV2/gke/variables.tf
@@ -1,0 +1,12 @@
+variable "project" {}
+variable "environment" {}
+variable "product" {}
+variable "owner" {}
+variable "maintainer" {}
+variable "machine_type" {}
+variable "location" {}
+variable "region" {}
+variable "credentials" {}
+variable "db_backup_start_time" {}
+variable "db_instance_tier" {}
+variable "db_user" {}

--- a/terraformV2/main.tf
+++ b/terraformV2/main.tf
@@ -1,0 +1,35 @@
+locals {
+  region   = "${terraform.workspace == "staging" ? "us-central1" : "europe-west1"}"
+  location = "${terraform.workspace == "staging" ? "us-central1-a" : "europe-west1-b"}"
+}
+
+terraform {
+  backend "gcs" {}
+}
+
+data "terraform_remote_state" "travela" {
+  backend = "gcs"
+
+  config = {
+    bucket      = "${var.bucket}"
+    prefix      = "terraform/state"
+    credentials = "${var.credentials}"
+  }
+}
+
+
+module "gke" {
+  source               = "./gke"
+  project              = "${var.project}"
+  environment          = "${terraform.workspace}"
+  machine_type         = "${var.machine_type}"
+  credentials          = "${var.credentials}"
+  region               = "${local.region}"
+  location             = "${local.location}"
+  product              = "${var.product}"
+  owner                = "${var.owner}"
+  maintainer           = "${var.maintainer}"
+  db_backup_start_time = "${var.db_backup_start_time}"
+  db_instance_tier     = "${var.db_instance_tier}"
+  db_user              = "${var.db_user}"
+}

--- a/terraformV2/variables.tf
+++ b/terraformV2/variables.tf
@@ -1,0 +1,10 @@
+variable "project" {}
+variable "owner" {}
+variable "maintainer" {}
+variable "bucket" {}
+variable "credentials" {}
+variable "product" {}
+variable "machine_type" {}
+variable "db_instance_tier" {}
+variable "db_backup_start_time" {}
+variable "db_user" {}


### PR DESCRIPTION
#### Description
For ease of set up of the application's infrastructure, the infrastructure has to be tied down to specific versions and configurations to ensure that it's consistent every-time it's deployed. These terraform scripts set this up and create the following:

1. VPC
2. Subnetwork
3. GKE cluster
4. Node pool
5. Database
5. Database instance
6. Database user and password
7. Static IP


#### Type of change
- [x] Infrastructure as Code

#### How Has This Been Tested?
With the correct values for the variables as well as the correct secret key from a GCP project, running the command 
```
terraform apply
```
will create the above named resources

#### Checklist:

#### JIRA
[DA-107](https://andela-apprenticeship.atlassian.net/browse/DA-107)
