### PR TITLE
DA-387 Add annotations to the ingress object

### DIFF
--- a/deploy/travela-production.ingress.yml.tpl
+++ b/deploy/travela-production.ingress.yml.tpl
@@ -12,6 +12,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-read-timeout: 86400
     nginx.ingress.kubernetes.io/proxy-send-timeout: 86400
+    nginx.ingress.kubernetes.io/limit-connections: 6
+    nginx.ingress.kubernetes.io/limit-rps: 6
+    nginx.ingress.kubernetes.io/limit-rate: 6
 spec:
   tls:
     - secretName: travela-tls-secrets

--- a/deploy/travela-qa.ingress.yml.tpl
+++ b/deploy/travela-qa.ingress.yml.tpl
@@ -12,6 +12,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-read-timeout: 86400
     nginx.ingress.kubernetes.io/proxy-send-timeout: 86400
+    nginx.ingress.kubernetes.io/limit-connections: 6
+    nginx.ingress.kubernetes.io/limit-rps: 6
+    nginx.ingress.kubernetes.io/limit-rate: 6
 spec:
   tls:
     - secretName: travela-tls-secrets

--- a/deploy/travela-staging.ingress.yml.tpl
+++ b/deploy/travela-staging.ingress.yml.tpl
@@ -12,6 +12,9 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
     nginx.ingress.kubernetes.io/proxy-read-timeout: 86400
     nginx.ingress.kubernetes.io/proxy-send-timeout: 86400
+    nginx.ingress.kubernetes.io/limit-connections: 6
+    nginx.ingress.kubernetes.io/limit-rps: 6
+    nginx.ingress.kubernetes.io/limit-rate: 6
 spec:
   tls:
     - secretName: travela-tls-secrets


### PR DESCRIPTION
#### Description
To prevent against Distributed Denial of Service attacks, one of the security measures is to limit the number of concurrent connections from a single IP to our application. This can be done through the kubernetes annotations added to the nginx-ingress. We limit the following:

            1. number of concurrent connections allowed from a single IP address
		2. number of connections that may be accepted from a given IP each second
		3. rate of request that accepted from a client each second

#### Type of change
- [x] New feature to secure the application

#### How Has This Been Tested?
Using a tool such as apache benchmark to test out the number of allowed concurrent connections allowed.

#### Checklist:

#### JIRA
[DA-387](https://andela-apprenticeship.atlassian.net/browse/DA-387)
