### PR TITLE
DA-412 Add pod resource limits

### DIFF
--- a/deploy/travela-backend.deployment.yml.tpl
+++ b/deploy/travela-backend.deployment.yml.tpl
@@ -131,6 +131,13 @@ spec:
                 secretKeyRef:
                   name: {{ PROJECT_NAME }}-secrets
                   key: CrashReportingChannel
+          resources:
+            limits:
+              cpu: 300m
+              memory: 450Mi
+            requests:
+              cpu: 100m
+              memory: 150Mi 
           readinessProbe:
             httpGet:
               path: /api/v1/_healthz

--- a/deploy/travela-frontend.deployment.yml.tpl
+++ b/deploy/travela-frontend.deployment.yml.tpl
@@ -28,8 +28,8 @@ spec:
               memory: "64Mi"
               cpu: "100m"
             limits:
-              memory: "64Mi"
-              cpu: "100m"
+              memory: "192Mi"
+              cpu: "300m"
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
#### What does this PR do?
This PR introduces the resource block and sets the minimum amount of resources to be requested by a pod and also set the maximum limit to be requested by a pod

#### Description of Task to be completed?
Fix the random eviction of pods on the backend

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
*The problem*
>- The pods can get greedy and start using up all the available memory
>- Due to no resource limits sets, Kubernetes set the pods priority to low and this makes them good candidates for eviction  in the event of low memory issues
>- Also, the autoscaler does not work because it can't calculate the CPU utilization. Otherwise, I believe more pods would have been created to handle the spikes in traffic.

*Solution*
>- Set resource request and limits for the pods
>-  Ensure the autoscaler is working as intended.

#### What are the relevant pivotal tracker stories?
[DA-412](https://andela-apprenticeship.atlassian.net/browse/DA-412)

#### Screenshots (if appropriate)

#### Questions:
